### PR TITLE
Update to ratatui 0.30

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,9 +5,9 @@ edition = "2021"
 
 [dependencies]
 chrono = { version = "0.4", default-features = false, features = ["clock"]}
-itertools = { version= "0.12", default-features = false, features = ["use_alloc"] }
+itertools = { version= "0.14", default-features = false, features = ["use_alloc"] }
 ordered-float = { version = "4.0", default-features = false }
-ratatui = { version = "0.25.0", default-features = false }
+ratatui = { version = "0.30.2", default-features = false }
 tracing = { version = "0.1", default-features = false }
 unicode-segmentation = "1.10.1"
 
@@ -15,8 +15,8 @@ unicode-segmentation = "1.10.1"
 actix-rt = "2.9.0"
 awc = { version = "3.4.0", features = ["rustls-0_22-webpki-roots"] }
 chrono-tz = "0.6"
-crossterm = "0.27"
+crossterm = "0.29"
 futures = "0.3.30"
 indoc = "2"
-ratatui = "0.25.0"
+ratatui = "0.30.2"
 serde_json = "1.0.1"

--- a/examples/binance.rs
+++ b/examples/binance.rs
@@ -79,7 +79,9 @@ async fn run_app<B: Backend>(
 ) -> io::Result<()> {
     let mut last_tick = Instant::now();
     loop {
-        terminal.draw(|f| ui(f, &mut app))?;
+        terminal
+            .draw(|f| ui(f, &mut app))
+            .expect("Failed to draw terminal frame");
 
         if !*app.is_loading_previous_candles.borrow() {
             let first_timestamp = app.candles.borrow().keys().next().cloned();
@@ -203,5 +205,5 @@ fn ui(f: &mut Frame, app: &mut App) {
                 .offset_from_utc_date(&Utc::now().naive_utc().date())
                 .fix(),
         );
-    f.render_stateful_widget(chart, f.size(), &mut app.state);
+    f.render_stateful_widget(chart, f.area(), &mut app.state);
 }

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -563,7 +563,9 @@ fn run_app<B: Backend>(
 ) -> io::Result<()> {
     let mut last_tick = Instant::now();
     loop {
-        terminal.draw(|f| ui(f, &mut app))?;
+        terminal
+            .draw(|f| ui(f, &mut app))
+            .expect("Failed to draw terminal frame");
 
         let timeout = tick_rate.saturating_sub(last_tick.elapsed());
         if crossterm::event::poll(timeout)? {
@@ -584,5 +586,5 @@ fn run_app<B: Backend>(
 
 fn ui(f: &mut Frame, app: &mut App) {
     let chart = CandleStickChart::new(Interval::OneMinute).candles(app.candles.clone());
-    f.render_stateful_widget(chart, f.size(), &mut app.state);
+    f.render_stateful_widget(chart, f.area(), &mut app.state);
 }

--- a/src/candlestick_chart.rs
+++ b/src/candlestick_chart.rs
@@ -82,8 +82,8 @@ impl Styled for CandleStickChart {
         self.style
     }
 
-    fn set_style(self, style: Style) -> Self::Item {
-        self.style(style)
+    fn set_style<S: Into<Style>>(self, style: S) -> Self::Item {
+        self.style(style.into())
     }
 }
 
@@ -232,7 +232,7 @@ impl StatefulWidget for CandleStickChart {
             };
 
             for (y, char) in rendered.iter().enumerate() {
-                buf.get_mut(x as u16 + y_axis_width + offset, y as u16)
+                buf[(x as u16 + y_axis_width + offset, y as u16)]
                     .set_symbol(char)
                     .set_style(Style::default().fg(color));
             }
@@ -244,10 +244,9 @@ impl StatefulWidget for CandleStickChart {
 #[cfg(test)]
 mod tests {
     use ratatui::{
-        assert_buffer_eq,
         buffer::{Buffer, Cell},
         layout::Rect,
-        style::{Style, Stylize},
+        style::Style,
         widgets::StatefulWidget,
     };
 
@@ -257,9 +256,9 @@ mod tests {
         let area = Rect::new(0, 0, width, height);
         let mut cell = Cell::default();
         cell.set_symbol("x");
-        let mut buffer = Buffer::filled(area, &cell);
+        let mut buffer = Buffer::filled(area, cell);
         widget.render(area, &mut buffer, &mut CandleStickChartState::default());
-        buffer.set_style(area, Style::default().reset());
+        buffer.set_style(area, Style::reset());
         buffer
     }
 
@@ -267,7 +266,7 @@ mod tests {
     fn empty_candle() {
         let widget = CandleStickChart::new(Interval::OneMinute).candles(vec![]);
         let buffer = render(widget, 14, 8);
-        assert_buffer_eq!(
+        assert_eq!(
             buffer,
             Buffer::with_lines(vec![
                 "xxxxxxxxxxxxxx",
@@ -287,7 +286,7 @@ mod tests {
         let widget = CandleStickChart::new(Interval::OneMinute)
             .candles(vec![Candle::new(0, 0.9, 3.0, 0.0, 2.1).unwrap()]);
         let buffer = render(widget, 14, 8);
-        assert_buffer_eq!(
+        assert_eq!(
             buffer,
             Buffer::with_lines(vec![
                 "     3.000 ├ │",
@@ -307,7 +306,7 @@ mod tests {
         let widget = CandleStickChart::new(Interval::OneMinute)
             .candles(vec![Candle::new(0, 0.9, 3.0, 0.0, 2.1).unwrap()]);
         let buffer = render(widget, 30, 8);
-        assert_buffer_eq!(
+        assert_eq!(
             buffer,
             Buffer::with_lines(vec![
                 "     3.000 ├ xxxxxxxxxxxxxxxx│",
@@ -330,7 +329,7 @@ mod tests {
             Candle::new(120000, 3.9, 4.1, 2.0, 2.3).unwrap(),
         ]);
         let buffer = render(widget, 19, 8);
-        assert_buffer_eq!(
+        assert_eq!(
             buffer,
             Buffer::with_lines(vec![
                 "     4.200 ├ xxx ╽┃",
@@ -355,7 +354,7 @@ mod tests {
             Candle::new(240000, 2.0, 5.2, 0.9, 3.9).unwrap(),
         ]);
         let buffer = render(widget, 19, 8);
-        assert_buffer_eq!(
+        assert_eq!(
             buffer,
             Buffer::with_lines(vec![
                 "     5.200 ├ x ╷  │",
@@ -377,7 +376,7 @@ mod tests {
             Candle::new(240000, 2.0, 5.2, 0.9, 3.9).unwrap(),
         ]);
         let buffer = render(widget, 19, 8);
-        assert_buffer_eq!(
+        assert_eq!(
             buffer,
             Buffer::with_lines(vec![
                 "     5.200 ├ x xxx│",
@@ -400,7 +399,7 @@ mod tests {
             Candle::new(2000, 500.0, 500.0, 500.0, 500.0).unwrap(),
         ]);
         let buffer = render(widget, 16, 8);
-        assert_buffer_eq!(
+        assert_eq!(
             buffer,
             Buffer::with_lines(vec![
                 "  1000.000 ├ │  ",
@@ -423,7 +422,7 @@ mod tests {
             Candle::new(2000, 580.0, 580.0, 320.0, 320.0).unwrap(),
         ]);
         let buffer = render(widget, 16, 8);
-        assert_buffer_eq!(
+        assert_eq!(
             buffer,
             Buffer::with_lines(vec![
                 "  1000.000 ├ │  ",

--- a/src/x_axis.rs
+++ b/src/x_axis.rs
@@ -1,4 +1,4 @@
-use chrono::{DateTime, FixedOffset, NaiveDateTime, TimeZone, Utc};
+use chrono::{DateTime, FixedOffset, TimeZone, Utc};
 use itertools::Itertools;
 
 enum Precision {
@@ -108,10 +108,7 @@ impl XAxis {
 
         let full_timestamps = (self.min..=self.max)
             .step_by(self.interval as usize * 1000)
-            .map(|t| {
-                let naive = NaiveDateTime::from_timestamp_millis(t).unwrap();
-                (t, Utc.from_utc_datetime(&naive))
-            })
+            .map(|t| (t, DateTime::from_timestamp_millis(t).unwrap()))
             .collect_vec();
         let full_timestamps_len = full_timestamps.len();
         let timestamps = if full_timestamps_len > width {


### PR DESCRIPTION
This PR updates Ratatui to the latest version (0.30.2).

## Changes
Updated dependencies:
- `ratatui` from 0.25.0 -> 0.30.2
- `crossterm` from 0.27 -> 0.29 (examples)
- `itertools` from 0.12 -> 0.14

Fixed breaking changes and deprecations.

This should make the crate usable with modern Ratatui apps.